### PR TITLE
Setup users by hardware

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-firestore:24.4.0'
     implementation 'com.google.firebase:firebase-analytics:21.2.0'
     implementation 'com.google.firebase:firebase-storage:20.1.0'
+    implementation 'com.google.firebase:firebase-installations:17.1.0'
     implementation 'com.squareup.picasso:picasso:2.8'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation "androidx.test:runner:1.4.0"

--- a/app/src/androidTest/java/com/example/wellfed/IngredientDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/IngredientDBTest.java
@@ -50,7 +50,7 @@ public class IngredientDBTest {
      */
     @Before
     public void before() {
-        ingredientDB = new IngredientDB(InstrumentationRegistry.getInstrumentation().getContext());
+        ingredientDB = new IngredientDB(null, true);
         mockIngredient = new Ingredient("Broccoli");
         mockIngredient.setCategory("Vegetable");
         nonExistingIngredient = new Ingredient(null);

--- a/app/src/androidTest/java/com/example/wellfed/IngredientDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/IngredientDBTest.java
@@ -11,6 +11,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import android.util.Log;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.example.wellfed.ingredient.Ingredient;
 import com.example.wellfed.ingredient.IngredientDB;
@@ -49,7 +50,7 @@ public class IngredientDBTest {
      */
     @Before
     public void before() {
-        ingredientDB = new IngredientDB();
+        ingredientDB = new IngredientDB(InstrumentationRegistry.getInstrumentation().getContext());
         mockIngredient = new Ingredient("Broccoli");
         mockIngredient.setCategory("Vegetable");
         nonExistingIngredient = new Ingredient(null);

--- a/app/src/androidTest/java/com/example/wellfed/IngredientDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/IngredientDBTest.java
@@ -50,7 +50,8 @@ public class IngredientDBTest {
      */
     @Before
     public void before() {
-        ingredientDB = new IngredientDB(null, true);
+        MockDBConnection connection = new MockDBConnection();
+        ingredientDB = new IngredientDB(connection);
         mockIngredient = new Ingredient("Broccoli");
         mockIngredient.setCategory("Vegetable");
         nonExistingIngredient = new Ingredient(null);

--- a/app/src/androidTest/java/com/example/wellfed/MockDBConnection.java
+++ b/app/src/androidTest/java/com/example/wellfed/MockDBConnection.java
@@ -1,0 +1,37 @@
+package com.example.wellfed;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.example.wellfed.common.DBConnection;
+
+import java.util.UUID;
+
+/**
+ * This class mocks a DB connection for testing.
+ * The main difference between this class and the DBConnection class is that
+ * the DBConnection class requires the context to save the UUID, but this mock
+ * connection class creates a new UUID (without saving it locally) for tests
+ */
+public class MockDBConnection extends DBConnection {
+    /**
+     * Connects to the Firebase Firestore database, at the given subcollection.
+     * The user is given by the FID, which is a Firebase ID given to each unique installation.
+     *
+     */
+    public MockDBConnection() {
+        super(null);
+    }
+
+    /**
+     * Gets the UUID of the device, to identify the user.
+     * Since this is a mock class,
+     *
+     * @param context: the context of the application
+     */
+    @Override
+    protected String getUUID(Context context) {
+        String uuid = "test" + UUID.randomUUID().toString();
+        return uuid;
+    }
+}

--- a/app/src/androidTest/java/com/example/wellfed/RecipeDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/RecipeDBTest.java
@@ -3,6 +3,7 @@ package com.example.wellfed;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.example.wellfed.ingredient.Ingredient;
 import com.example.wellfed.recipe.Recipe;
@@ -27,7 +28,7 @@ public class RecipeDBTest {
 
     @Before
     public void before() {
-        recipeDB = new RecipeDB();
+        recipeDB = new RecipeDB(InstrumentationRegistry.getInstrumentation().getContext());
     }
 
     /**

--- a/app/src/androidTest/java/com/example/wellfed/RecipeDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/RecipeDBTest.java
@@ -28,7 +28,7 @@ public class RecipeDBTest {
 
     @Before
     public void before() {
-        recipeDB = new RecipeDB(InstrumentationRegistry.getInstrumentation().getContext());
+        recipeDB = new RecipeDB(null, true);
     }
 
     /**

--- a/app/src/androidTest/java/com/example/wellfed/RecipeDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/RecipeDBTest.java
@@ -28,7 +28,8 @@ public class RecipeDBTest {
 
     @Before
     public void before() {
-        recipeDB = new RecipeDB(null, true);
+        MockDBConnection connection = new MockDBConnection();
+        recipeDB = new RecipeDB(connection);
     }
 
     /**

--- a/app/src/androidTest/java/com/example/wellfed/StorageIngredientDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/StorageIngredientDBTest.java
@@ -30,7 +30,8 @@ import java.util.concurrent.CountDownLatch;
     StorageIngredient mockStorageIngredient;
 
     @Before public void before() {
-        storageIngredientDB = new StorageIngredientDB(null, true);
+        MockDBConnection connection = new MockDBConnection();
+        storageIngredientDB = new StorageIngredientDB(connection);
         mockStorageIngredient =
                 new StorageIngredient("Broccoli", 5.0, "kg", "Fridge",
                         new Date(), "Vegetable");

--- a/app/src/androidTest/java/com/example/wellfed/StorageIngredientDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/StorageIngredientDBTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.example.wellfed.ingredient.StorageIngredient;
 import com.example.wellfed.ingredient.StorageIngredientDB;
@@ -29,7 +30,7 @@ import java.util.concurrent.CountDownLatch;
     StorageIngredient mockStorageIngredient;
 
     @Before public void before() {
-        storageIngredientDB = new StorageIngredientDB();
+        storageIngredientDB = new StorageIngredientDB(InstrumentationRegistry.getInstrumentation().getContext());
         mockStorageIngredient =
                 new StorageIngredient("Broccoli", 5.0, "kg", "Fridge",
                         new Date(), "Vegetable");

--- a/app/src/androidTest/java/com/example/wellfed/StorageIngredientDBTest.java
+++ b/app/src/androidTest/java/com/example/wellfed/StorageIngredientDBTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CountDownLatch;
     StorageIngredient mockStorageIngredient;
 
     @Before public void before() {
-        storageIngredientDB = new StorageIngredientDB(InstrumentationRegistry.getInstrumentation().getContext());
+        storageIngredientDB = new StorageIngredientDB(null, true);
         mockStorageIngredient =
                 new StorageIngredient("Broccoli", 5.0, "kg", "Fridge",
                         new Date(), "Vegetable");

--- a/app/src/main/java/com/example/wellfed/MainActivity.java
+++ b/app/src/main/java/com/example/wellfed/MainActivity.java
@@ -6,16 +6,19 @@ import androidx.fragment.app.FragmentManager;
 import androidx.viewpager2.widget.ViewPager2;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.Menu;
 
 
+import com.example.wellfed.common.DBConnection;
 import com.example.wellfed.common.Launcher;
 import com.google.android.material.bottomappbar.BottomAppBar;
 import com.example.wellfed.navigation.NavigationCollectionAdapter;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.Stack;
+import java.util.UUID;
 
 public class MainActivity extends ActivityBase {
     final String TAG = "MainActivity";

--- a/app/src/main/java/com/example/wellfed/common/DBConnection.java
+++ b/app/src/main/java/com/example/wellfed/common/DBConnection.java
@@ -45,10 +45,10 @@ public class DBConnection {
      *
      * @param subcollection The subcollection within the user to connect to
      */
-    public DBConnection(Context context, String subcollection) {
+    public DBConnection(Context context, String subcollection, boolean isTest) {
         this.db = FirebaseFirestore.getInstance();
         // gets the unique ID of the installation
-        String uuid = getUUID(context);
+        String uuid = getUUID(context, isTest);
         this.collection = db.collection("users")
                 .document("user" + uuid).collection(subcollection);
     }
@@ -57,7 +57,13 @@ public class DBConnection {
      * Gets the UUID of the device, to identify the user.
      * Creates a new UUID for the user if they do not already have one.
      */
-    private String getUUID(Context context) {
+    private String getUUID(Context context, boolean isTest) {
+        // Since a test user does not have a valid context, we must create a TEST string
+        if (isTest) {
+            String testID = "TEST";
+            return testID;
+        }
+
         SharedPreferences sharedPreferences;
         sharedPreferences = context.getApplicationContext()
                 .getSharedPreferences("pref", Context.MODE_PRIVATE);

--- a/app/src/main/java/com/example/wellfed/common/DBConnection.java
+++ b/app/src/main/java/com/example/wellfed/common/DBConnection.java
@@ -38,24 +38,30 @@ public class DBConnection {
      */
     private CollectionReference collection;
 
+    /**
+     * Holds the UUID for a user.
+     */
+    private String uuid;
 
     /**
      * Connects to the Firebase Firestore database, at the given subcollection.
      * The user is given by the FID, which is a Firebase ID given to each unique installation.
      *
-     * @param subcollection The subcollection within the user to connect to
+     * @param context: the context of the application
+     * @param isTest:  indicates whether the DBConnection is being run as test or not
      */
-    public DBConnection(Context context, String subcollection, boolean isTest) {
+    public DBConnection(Context context, boolean isTest) {
         this.db = FirebaseFirestore.getInstance();
         // gets the unique ID of the installation
-        String uuid = getUUID(context, isTest);
-        this.collection = db.collection("users")
-                .document("user" + uuid).collection(subcollection);
+        this.uuid = getUUID(context, isTest);
     }
 
     /**
      * Gets the UUID of the device, to identify the user.
      * Creates a new UUID for the user if they do not already have one.
+     *
+     * @param context: the context of the application
+     * @param isTest:  indicates whether the DBConnection is being run as test or not
      */
     private String getUUID(Context context, boolean isTest) {
         // Since a test user does not have a valid context, we must create a TEST string
@@ -84,12 +90,18 @@ public class DBConnection {
     /**
      * Gets the collection reference of the user's subcollection.
      *
-     * @return the CollectionReference specific to a user and subcollection
+     * @param subcollection the subcollection for a user to get
+     * @return the collection that was retrieved
      */
-    public CollectionReference getCollection() {
-        return this.collection;
+    public CollectionReference getCollection(String subcollection) {
+        return this.db.collection("users")
+                .document("user" + uuid).collection(subcollection);
     }
 
+    /**
+     * Gets the DB
+     * @return the DB
+     */
     public FirebaseFirestore getDB() {
         return this.db;
     }

--- a/app/src/main/java/com/example/wellfed/common/DBConnection.java
+++ b/app/src/main/java/com/example/wellfed/common/DBConnection.java
@@ -1,0 +1,101 @@
+package com.example.wellfed.common;
+
+import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.installations.FirebaseInstallations;
+
+/**
+ * Connects to the DB, getting the users unique FirestoreID to identify them.
+ * Citation: https://firebase.google.com/docs/projects/manage-installations#android
+ */
+public class DBConnection {
+    /**
+     * Holds the TAG for logging.
+     */
+    private static final String TAG = "DBConnection";
+
+    /**
+     * Holds the instance of the Firebase Firestore DB.
+     */
+    private FirebaseFirestore db;
+
+    /**
+     * Holds a reference to the User's collection (with specific subcollection) in the Firebase DB.
+     */
+    private CollectionReference collection;
+
+    /**
+     * The OnGetFIDListener interface is used to handle the result
+     * of the getFID method.
+     */
+    public interface OnGetFIDListener {
+        /**
+         * Called when the deleteIngredient method is complete.
+         *
+         * @param FID        The FID that was obtained from the
+         *                   database.
+         * @param success    True if the operation was successful, false
+         *                   otherwise
+         */
+        void onGetFID(String FID, Boolean success);
+    }
+
+    /**
+     * Connects to the Firebase Firestore database, at the given subcollection.
+     * The user is given by the FID, which is a Firebase ID given to each unique installation.
+     *
+     * @param subcollection The subcollection within the user to connect to
+     */
+    public DBConnection(String subcollection) {
+        this.db = FirebaseFirestore.getInstance();
+        // gets the unique ID of the installation
+        getFID(
+                (FID, success) -> {
+                    if (!success) {
+                        this.collection = null;
+                    } else {
+                        this.collection =
+                                db.collection("users").document("user"+FID)
+                                        .collection(subcollection);
+                    }
+                }
+        );
+    }
+
+    /**
+     * Gets the FID of the device, to identify the user.
+     */
+    private void getFID(OnGetFIDListener listener) {
+        FirebaseInstallations.getInstance().getId()
+                .addOnCompleteListener(new OnCompleteListener<String>() {
+                    @Override
+                    public void onComplete(@NonNull Task<String> task) {
+                        Log.d(TAG, "getFID:onComplete");
+                        if (task.isSuccessful()) {
+                            Log.d(TAG, ":isSuccessful:" + task.getResult());
+                            listener.onGetFID(task.getResult(), true);
+                        } else {
+                            Log.d(TAG, ":isFailure: Unable to get Installation ID");
+                            listener.onGetFID(null, false);
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Gets the collection reference of the user's subcollection.
+     *
+     * @return the CollectionReference specific to a user and subcollection
+     */
+    public CollectionReference getCollection() {
+        return this.collection;
+    }
+}

--- a/app/src/main/java/com/example/wellfed/common/DBConnection.java
+++ b/app/src/main/java/com/example/wellfed/common/DBConnection.java
@@ -43,12 +43,11 @@ public class DBConnection {
      * The user is given by the FID, which is a Firebase ID given to each unique installation.
      *
      * @param context: the context of the application
-     * @param isTest:  indicates whether the DBConnection is being run as test or not
      */
-    public DBConnection(Context context, boolean isTest) {
+    public DBConnection(Context context) {
         this.db = FirebaseFirestore.getInstance();
         // gets the unique ID of the installation
-        this.uuid = getUUID(context, isTest);
+        this.uuid = getUUID(context);
     }
 
     /**
@@ -56,16 +55,8 @@ public class DBConnection {
      * Creates a new UUID for the user if they do not already have one.
      *
      * @param context: the context of the application
-     * @param isTest:  indicates whether the DBConnection is being run as test or not
      */
-    private String getUUID(Context context, boolean isTest) {
-        // Since a test user does not have a valid context, we must create a TEST string
-        if (isTest) {
-            uuid = UUID.randomUUID().toString();
-            String testID = "test" + uuid;
-            return testID;
-        }
-
+    protected String getUUID(Context context) {
         SharedPreferences sharedPreferences;
         sharedPreferences = context.getApplicationContext()
                 .getSharedPreferences("pref", Context.MODE_PRIVATE);

--- a/app/src/main/java/com/example/wellfed/common/DBConnection.java
+++ b/app/src/main/java/com/example/wellfed/common/DBConnection.java
@@ -23,11 +23,6 @@ import java.util.UUID;
  */
 public class DBConnection {
     /**
-     * Holds the TAG for logging.
-     */
-    private static final String TAG = "DBConnection";
-
-    /**
      * Holds the instance of the Firebase Firestore DB.
      */
     private FirebaseFirestore db;
@@ -66,7 +61,8 @@ public class DBConnection {
     private String getUUID(Context context, boolean isTest) {
         // Since a test user does not have a valid context, we must create a TEST string
         if (isTest) {
-            String testID = "TEST";
+            uuid = UUID.randomUUID().toString();
+            String testID = "test" + uuid;
             return testID;
         }
 

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
@@ -1,5 +1,6 @@
 package com.example.wellfed.ingredient;
 
+import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -40,8 +41,9 @@ public class IngredientDB {
     /**
      * Constructs an IngredientDB object
      */
-    public IngredientDB() {
-        this.ingredientsConnection = new DBConnection("Ingredients");
+    public IngredientDB(Context context) {
+        this.ingredientsConnection = new DBConnection(context, "Ingredients");
+        db = this.ingredientsConnection.getDB();
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
@@ -41,8 +41,8 @@ public class IngredientDB {
     /**
      * Constructs an IngredientDB object
      */
-    public IngredientDB(Context context) {
-        this.ingredientsConnection = new DBConnection(context, "Ingredients");
+    public IngredientDB(Context context, boolean isTest) {
+        this.ingredientsConnection = new DBConnection(context, "Ingredients", isTest);
         db = this.ingredientsConnection.getDB();
     }
 

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.example.wellfed.common.DBConnection;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -31,16 +32,16 @@ public class IngredientDB {
      */
     private FirebaseFirestore db;
     /**
-     * Holds a reference to the Ingredients collection in the Firebase DB.
+     * Holds a connection to the users ingredient collection in the DB.
      */
-    private CollectionReference collection;
+    private DBConnection ingredientsConnection;
+
 
     /**
      * Constructs an IngredientDB object
      */
     public IngredientDB() {
-        this.db = FirebaseFirestore.getInstance();
-        this.collection = db.collection("Ingredients");
+        this.ingredientsConnection = new DBConnection("Ingredients");
     }
 
     /**
@@ -120,8 +121,8 @@ public class IngredientDB {
         WriteBatch batch = db.batch();
 
         // add ingredient info to batch
-        String ingredientId = this.collection.document().getId();
-        DocumentReference ingredientRef = collection.document(ingredientId);
+        String ingredientId = ingredientsConnection.getCollection().document().getId();
+        DocumentReference ingredientRef = ingredientsConnection.getCollection().document(ingredientId);
         Map<String, Object> item = new HashMap<>();
         item.put("category", ingredient.getCategory());
         item.put("description", ingredient.getDescription());
@@ -148,7 +149,7 @@ public class IngredientDB {
      *                 retrieved
      */
     public void getIngredient(String id, OnGetIngredientListener listener) {
-        DocumentReference ingredientRef = collection.document(id);
+        DocumentReference ingredientRef = ingredientsConnection.getCollection().document(id);
         getIngredient(ingredientRef, listener);
     }
 
@@ -191,7 +192,7 @@ public class IngredientDB {
 
     public void getIngredient(Ingredient ingredient,
                               OnGetIngredientListener listener) {
-        collection.whereEqualTo("category", ingredient.getCategory())
+        ingredientsConnection.getCollection().whereEqualTo("category", ingredient.getCategory())
                 .whereEqualTo("description", ingredient.getDescription())
                 .limit(1).get().addOnCompleteListener(task -> {
                     if (task.isSuccessful()) {
@@ -226,7 +227,7 @@ public class IngredientDB {
         WriteBatch batch = db.batch();
 
         DocumentReference ingredientDocument =
-                collection.document(ingredient.getId());
+                ingredientsConnection.getCollection().document(ingredient.getId());
         batch.delete(ingredientDocument);
 
         batch.commit().addOnCompleteListener(task -> {
@@ -250,7 +251,7 @@ public class IngredientDB {
     public void updateReferenceCount(Ingredient ingredient, int delta,
                                      OnUpdateIngredientReferenceCountListener listener) {
         String id = getDocumentReference(ingredient).getId();
-        collection.document(id).get()
+        ingredientsConnection.getCollection().document(id).get()
                 .addOnCompleteListener(task -> {
                     if (task.isSuccessful()) {
                         DocumentSnapshot document = task.getResult();
@@ -261,7 +262,7 @@ public class IngredientDB {
                             }
                             count += delta;
                             if (count > 0) {
-                                collection.document(id)
+                                ingredientsConnection.getCollection().document(id)
                                         .update("count", count)
                                         .addOnCompleteListener(task1 -> {
                                             listener.onUpdateReferenceCount(
@@ -307,11 +308,11 @@ public class IngredientDB {
      * @return the document reference
      */
     public DocumentReference getDocumentReference(Ingredient ingredient) {
-        return collection.document(ingredient.getId());
+        return ingredientsConnection.getCollection().document(ingredient.getId());
     }
 
 
     public Query getQuery(){
-        return collection;
+        return ingredientsConnection.getCollection();
     }
 }

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientDB.java
@@ -44,8 +44,8 @@ public class IngredientDB {
     /**
      * Constructs an IngredientDB object
      */
-    public IngredientDB(Context context, boolean isTest) {
-        this.ingredientsConnection = new DBConnection(context, isTest);
+    public IngredientDB(DBConnection connection) {
+        this.ingredientsConnection = connection;
         db = this.ingredientsConnection.getDB();
         collection = this.ingredientsConnection.getCollection("Ingredients");
     }

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientStorageController.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientStorageController.java
@@ -26,7 +26,7 @@ public class IngredientStorageController {
      */
     public IngredientStorageController(FragmentActivity activity) {
         this.activity = (ActivityBase) activity;
-        db = new StorageIngredientDB(activity.getApplicationContext());
+        db = new StorageIngredientDB(activity.getApplicationContext(), false);
         adapter = new StorageIngredientAdapter(db);
     }
 

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientStorageController.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientStorageController.java
@@ -4,6 +4,7 @@ package com.example.wellfed.ingredient;
 import androidx.fragment.app.FragmentActivity;
 
 import com.example.wellfed.ActivityBase;
+import com.example.wellfed.common.DBConnection;
 
 public class IngredientStorageController {
     /**
@@ -26,7 +27,8 @@ public class IngredientStorageController {
      */
     public IngredientStorageController(FragmentActivity activity) {
         this.activity = (ActivityBase) activity;
-        db = new StorageIngredientDB(activity.getApplicationContext(), false);
+        DBConnection connection = new DBConnection(activity.getApplicationContext());
+        db = new StorageIngredientDB(connection);
         adapter = new StorageIngredientAdapter(db);
     }
 

--- a/app/src/main/java/com/example/wellfed/ingredient/IngredientStorageController.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/IngredientStorageController.java
@@ -26,7 +26,7 @@ public class IngredientStorageController {
      */
     public IngredientStorageController(FragmentActivity activity) {
         this.activity = (ActivityBase) activity;
-        db = new StorageIngredientDB();
+        db = new StorageIngredientDB(activity.getApplicationContext());
         adapter = new StorageIngredientAdapter(db);
     }
 

--- a/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.example.wellfed.common.DBConnection;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -24,13 +25,13 @@ public class StorageIngredientDB {
      */
     private FirebaseFirestore db;
     /**
-     * Holds a reference to the StoredIngredients collection in the Firebase DB.
-     */
-    private final CollectionReference collection;
-    /**
      * Holds a reference to the IngredientDB
      */
     private final IngredientDB ingredientDB;
+    /**
+     * Holds a connection to the users ingredient collection in the DB.
+     */
+    private DBConnection ingredientsConnection;
 
     /**
      * This interface is used to handle the result of
@@ -102,7 +103,7 @@ public class StorageIngredientDB {
      */
     public StorageIngredientDB() {
         this.db = FirebaseFirestore.getInstance();
-        this.collection = db.collection("StoredIngredients");
+        this.ingredientsConnection = new DBConnection("StoredIngredients");
         this.ingredientDB = new IngredientDB();
     }
 
@@ -160,7 +161,7 @@ public class StorageIngredientDB {
         storageIngredientMap.put("unit", storageIngredient.getUnit());
         storageIngredientMap.put("Ingredient",
                 ingredientDB.getDocumentReference(ingredient));
-        this.collection.add(storageIngredientMap)
+        this.ingredientsConnection.getCollection().add(storageIngredientMap)
                 .addOnSuccessListener(stored -> {
                     Log.d(TAG, "success:");
                     storageIngredient.setStorageId(stored.getId());
@@ -230,7 +231,7 @@ public class StorageIngredientDB {
                                         OnUpdateStorageIngredientListener listener) {
         WriteBatch batch = db.batch();
         DocumentReference storageIngredientRef =
-                collection.document(storageIngredient.getStorageId());
+                this.ingredientsConnection.getCollection().document(storageIngredient.getStorageId());
         batch.update(storageIngredientRef, "unit", storageIngredient.getUnit());
         batch.update(storageIngredientRef, "amount",
                 storageIngredient.getAmount());
@@ -273,7 +274,7 @@ public class StorageIngredientDB {
     public void deleteStorageIngredient(StorageIngredient storageIngredient,
                                         OnDeleteStorageIngredientListener listener) {
         // TODO: based on number of references to ingredient, delete ingredient
-        this.collection.document(storageIngredient.getStorageId()).delete()
+        this.ingredientsConnection.getCollection().document(storageIngredient.getStorageId()).delete()
                 .addOnSuccessListener(onDelete -> {
                     Log.d(TAG, "DocumentSnapshot successfully deleted!");
                     ingredientDB.updateReferenceCount(storageIngredient, -1,
@@ -325,7 +326,7 @@ public class StorageIngredientDB {
      */
     public void getStorageIngredient(String id,
                                      OnGetStorageIngredientListener listener) {
-        this.collection.document(id).get()
+        this.ingredientsConnection.getCollection().document(id).get()
                 .addOnSuccessListener(storedSnapshot -> {
                     Log.d(TAG, "StorageIngredient found");
                     this.getStorageIngredient(storedSnapshot, listener);
@@ -380,7 +381,7 @@ public class StorageIngredientDB {
      * @return DocumentReference of the Recipe
      */
     public DocumentReference getDocumentReference(String id) {
-        return collection.document(id);
+        return this.ingredientsConnection.getCollection().document(id);
     }
 
     /**
@@ -389,7 +390,7 @@ public class StorageIngredientDB {
      * @return the query
      */
     public Query getQuery() {
-        return collection;
+        return this.ingredientsConnection.getCollection();
         //                .orderBy("timestamp", Query.Direction.DESCENDING)
     }
 }

--- a/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
@@ -106,9 +106,9 @@ public class StorageIngredientDB {
     /**
      * Creates a reference to the Firebase DB.
      */
-    public StorageIngredientDB(Context context, boolean isTest) {
-        this.ingredientsConnection = new DBConnection(context, isTest);
-        this.ingredientDB = new IngredientDB(context, isTest);
+    public StorageIngredientDB(DBConnection connection) {
+        this.ingredientsConnection = connection;
+        this.ingredientDB = new IngredientDB(connection);
         this.db = ingredientsConnection.getDB();
         this.collection = ingredientsConnection.getCollection("StoredIngredients");
     }

--- a/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
@@ -102,10 +102,10 @@ public class StorageIngredientDB {
     /**
      * Creates a reference to the Firebase DB.
      */
-    public StorageIngredientDB(Context context) {
+    public StorageIngredientDB(Context context, boolean isTest) {
         this.db = FirebaseFirestore.getInstance();
-        this.ingredientsConnection = new DBConnection(context,"StoredIngredients", false);
-        this.ingredientDB = new IngredientDB(context, false);
+        this.ingredientsConnection = new DBConnection(context,"StoredIngredients", isTest);
+        this.ingredientDB = new IngredientDB(context, isTest);
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
@@ -1,5 +1,6 @@
 package com.example.wellfed.ingredient;
 
+import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -101,10 +102,10 @@ public class StorageIngredientDB {
     /**
      * Creates a reference to the Firebase DB.
      */
-    public StorageIngredientDB() {
+    public StorageIngredientDB(Context context) {
         this.db = FirebaseFirestore.getInstance();
-        this.ingredientsConnection = new DBConnection("StoredIngredients");
-        this.ingredientDB = new IngredientDB();
+        this.ingredientsConnection = new DBConnection(context,"StoredIngredients");
+        this.ingredientDB = new IngredientDB(context);
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
+++ b/app/src/main/java/com/example/wellfed/ingredient/StorageIngredientDB.java
@@ -104,8 +104,8 @@ public class StorageIngredientDB {
      */
     public StorageIngredientDB(Context context) {
         this.db = FirebaseFirestore.getInstance();
-        this.ingredientsConnection = new DBConnection(context,"StoredIngredients");
-        this.ingredientDB = new IngredientDB(context);
+        this.ingredientsConnection = new DBConnection(context,"StoredIngredients", false);
+        this.ingredientDB = new IngredientDB(context, false);
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeActivity.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeActivity.java
@@ -75,7 +75,7 @@ public class RecipeActivity extends ActivityBase implements ConfirmDialog.OnConf
         TextView description = findViewById(R.id.recipe_description_textView);
         ImageView img = findViewById(R.id.recipe_img);
 
-        RecipeDB recipeDB = new RecipeDB();
+        RecipeDB recipeDB = new RecipeDB(getApplicationContext());
         recipeDB.getRecipe(recipe.getId(), (foundRecipe, success) -> {
             recipe = foundRecipe;
             title.setText(recipe.getTitle());

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeActivity.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeActivity.java
@@ -75,7 +75,7 @@ public class RecipeActivity extends ActivityBase implements ConfirmDialog.OnConf
         TextView description = findViewById(R.id.recipe_description_textView);
         ImageView img = findViewById(R.id.recipe_img);
 
-        RecipeDB recipeDB = new RecipeDB(getApplicationContext());
+        RecipeDB recipeDB = new RecipeDB(getApplicationContext(), false);
         recipeDB.getRecipe(recipe.getId(), (foundRecipe, success) -> {
             recipe = foundRecipe;
             title.setText(recipe.getTitle());

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeActivity.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeActivity.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import com.example.wellfed.ActivityBase;
 import com.example.wellfed.R;
 import com.example.wellfed.common.ConfirmDialog;
+import com.example.wellfed.common.DBConnection;
 import com.example.wellfed.common.DeleteButton;
 import com.example.wellfed.ingredient.Ingredient;
 import com.squareup.picasso.Picasso;
@@ -75,7 +76,8 @@ public class RecipeActivity extends ActivityBase implements ConfirmDialog.OnConf
         TextView description = findViewById(R.id.recipe_description_textView);
         ImageView img = findViewById(R.id.recipe_img);
 
-        RecipeDB recipeDB = new RecipeDB(getApplicationContext(), false);
+        DBConnection connection = new DBConnection(getApplicationContext());
+        RecipeDB recipeDB = new RecipeDB(connection);
         recipeDB.getRecipe(recipe.getId(), (foundRecipe, success) -> {
             recipe = foundRecipe;
             title.setText(recipe.getTitle());

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
@@ -87,7 +87,7 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
                 Recipe recipe = result.second;
                 switch (type) {
                     case "save":
-                        RecipeDB recipeDB = new RecipeDB();
+                        RecipeDB recipeDB = new RecipeDB(getContext().getApplicationContext());
                         try {
                             recipeDB.addRecipe(recipe, (a, b) -> {
                             });
@@ -121,8 +121,8 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable
             ViewGroup container, @Nullable Bundle savedInstanceState) {
         recipes = new ArrayList<>();
-        recipeController = new RecipeController();
-        recipeDB = new RecipeDB();
+        recipeController = new RecipeController(getContext().getApplicationContext());
+        recipeDB = new RecipeDB(getContext().getApplicationContext());
         return inflater.inflate(R.layout.fragment_recipe_book, container, false);
     }
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
@@ -88,7 +88,7 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
                 Recipe recipe = result.second;
                 switch (type) {
                     case "save":
-                        RecipeDB recipeDB = new RecipeDB(requireContext().getApplicationContext());
+                        RecipeDB recipeDB = new RecipeDB(requireContext().getApplicationContext(), false);
                         try {
                             recipeDB.addRecipe(recipe, (a, b) -> {
                             });
@@ -123,7 +123,7 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
             ViewGroup container, @Nullable Bundle savedInstanceState) {
         recipes = new ArrayList<>();
         recipeController = new RecipeController(getContext().getApplicationContext());
-        recipeDB = new RecipeDB(getContext().getApplicationContext());
+        recipeDB = new RecipeDB(getContext().getApplicationContext(), false);
         return inflater.inflate(R.layout.fragment_recipe_book, container, false);
     }
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.wellfed.R;
+import com.example.wellfed.common.DBConnection;
 import com.example.wellfed.common.Launcher;
 import com.google.firebase.firestore.FirebaseFirestore;
 
@@ -88,7 +89,8 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
                 Recipe recipe = result.second;
                 switch (type) {
                     case "save":
-                        RecipeDB recipeDB = new RecipeDB(requireContext().getApplicationContext(), false);
+                        DBConnection connection = new DBConnection(requireContext().getApplicationContext());
+                        RecipeDB recipeDB = new RecipeDB(connection);
                         try {
                             recipeDB.addRecipe(recipe, (a, b) -> {
                             });
@@ -123,7 +125,8 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
             ViewGroup container, @Nullable Bundle savedInstanceState) {
         recipes = new ArrayList<>();
         recipeController = new RecipeController(getContext().getApplicationContext());
-        recipeDB = new RecipeDB(getContext().getApplicationContext(), false);
+        DBConnection connection = new DBConnection(getContext().getApplicationContext());
+        recipeDB = new RecipeDB(connection);
         return inflater.inflate(R.layout.fragment_recipe_book, container, false);
     }
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeBookFragment.java
@@ -19,6 +19,7 @@ import com.example.wellfed.common.Launcher;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 // todo create sample data for recipes
 // todo setup recipe edit button
@@ -87,7 +88,7 @@ public class RecipeBookFragment extends Fragment implements Launcher, RecipeAdap
                 Recipe recipe = result.second;
                 switch (type) {
                     case "save":
-                        RecipeDB recipeDB = new RecipeDB(getContext().getApplicationContext());
+                        RecipeDB recipeDB = new RecipeDB(requireContext().getApplicationContext());
                         try {
                             recipeDB.addRecipe(recipe, (a, b) -> {
                             });

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeController.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeController.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.media.Image;
 import android.util.Log;
 
+import com.example.wellfed.common.DBConnection;
 import com.example.wellfed.ingredient.Ingredient;
 
 import java.io.Serializable;
@@ -36,7 +37,8 @@ public class RecipeController {
      * Constructor that initializes the db
      */
     public RecipeController(Context context) {
-        recipeDB = new RecipeDB(context, false);
+        DBConnection connection = new DBConnection(context);
+        recipeDB = new RecipeDB(connection);
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeController.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeController.java
@@ -1,5 +1,6 @@
 package com.example.wellfed.recipe;
 
+import android.content.Context;
 import android.media.Image;
 import android.util.Log;
 
@@ -34,8 +35,8 @@ public class RecipeController {
     /**
      * Constructor that initializes the db
      */
-    public RecipeController() {
-        recipeDB = new RecipeDB();
+    public RecipeController(Context context) {
+        recipeDB = new RecipeDB(context);
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeController.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeController.java
@@ -36,7 +36,7 @@ public class RecipeController {
      * Constructor that initializes the db
      */
     public RecipeController(Context context) {
-        recipeDB = new RecipeDB(context);
+        recipeDB = new RecipeDB(context, false);
     }
 
     /**

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
@@ -48,10 +48,10 @@ public class RecipeDB {
     /**
      * Create a RecipeDB object
      */
-    public RecipeDB(Context context) {
-        this.recipesConnection = new DBConnection(context, "Recipes");
+    public RecipeDB(Context context, boolean isTest) {
+        this.recipesConnection = new DBConnection(context, "Recipes", isTest);
         db = this.recipesConnection.getDB();
-        ingredientDB = new IngredientDB(context);
+        ingredientDB = new IngredientDB(context, isTest);
     }
 
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
@@ -3,6 +3,7 @@ package com.example.wellfed.recipe;
 import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
 import static com.google.android.gms.common.internal.safeparcel.SafeParcelable.NULL;
 
+import android.content.Context;
 import android.util.Log;
 
 import com.example.wellfed.ingredient.Ingredient;
@@ -46,10 +47,10 @@ public class RecipeDB {
     /**
      * Create a RecipeDB object
      */
-    public RecipeDB() {
+    public RecipeDB(Context context) {
         db = FirebaseFirestore.getInstance();
         this.recipesCollection = db.collection("Recipes");
-        ingredientDB = new IngredientDB();
+        ingredientDB = new IngredientDB(context);
     }
 
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
@@ -33,9 +33,14 @@ public class RecipeDB {
      */
     private final IngredientDB ingredientDB;
     /**
-     * Holds a connection to the users recipe collection in the DB.
+     * Holds a connection to the DB.
      */
     private DBConnection recipesConnection;
+
+    /**
+     * Holds the CollectionReference for the users Recipe collection.
+     */
+    private CollectionReference collection;
 
     public interface OnRecipeDone {
         public void onAddRecipe(Recipe recipe, Boolean success);
@@ -49,8 +54,9 @@ public class RecipeDB {
      * Create a RecipeDB object
      */
     public RecipeDB(Context context, boolean isTest) {
-        this.recipesConnection = new DBConnection(context, "Recipes", isTest);
+        this.recipesConnection = new DBConnection(context, isTest);
         db = this.recipesConnection.getDB();
+        collection = this.recipesConnection.getCollection("Recipes");
         ingredientDB = new IngredientDB(context, isTest);
     }
 
@@ -123,7 +129,7 @@ public class RecipeDB {
         recipeMap.put("photograph", recipe.getPhotograph());
         recipeMap.put("preparation-time", recipe.getPrepTimeMinutes());
 
-        this.recipesConnection.getCollection()
+        this.collection
                 .add(recipeMap)
                 .addOnSuccessListener(addedSnapshot -> {
                     recipe.setId(addedSnapshot.getId());
@@ -138,7 +144,7 @@ public class RecipeDB {
     // todo call the listener when results fail
     // todo add db-tests for it
     public void getRecipe(String id, OnRecipeDone listener) {
-        DocumentReference recipeRef = this.recipesConnection.getCollection().document(id);
+        DocumentReference recipeRef = this.collection.document(id);
         recipeRef.get()
                 .addOnSuccessListener(doc -> {
                     List<Task<DocumentSnapshot>> tasks = new ArrayList<>();
@@ -201,7 +207,7 @@ public class RecipeDB {
             listener.onAddRecipe(null, false);
         }
 
-        DocumentReference recipeRef = this.recipesConnection.getCollection().document(id);
+        DocumentReference recipeRef = this.collection.document(id);
         recipeRef.delete()
                 .addOnSuccessListener(r->{
                     listener.onAddRecipe(new Recipe(id), true);
@@ -396,7 +402,7 @@ public class RecipeDB {
      * @return DocumentReference of the Recipe
      */
     public DocumentReference getDocumentReference(String id) {
-        return this.recipesConnection.getCollection().document(id);
+        return this.collection.document(id);
     }
 
 
@@ -421,7 +427,7 @@ public class RecipeDB {
     }
 
     public Query getQuery() {
-        return this.recipesConnection.getCollection();
+        return this.collection;
     }
 
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeDB.java
@@ -53,11 +53,11 @@ public class RecipeDB {
     /**
      * Create a RecipeDB object
      */
-    public RecipeDB(Context context, boolean isTest) {
-        this.recipesConnection = new DBConnection(context, isTest);
+    public RecipeDB(DBConnection connection) {
+        this.recipesConnection = connection;
         db = this.recipesConnection.getDB();
         collection = this.recipesConnection.getCollection("Recipes");
-        ingredientDB = new IngredientDB(context, isTest);
+        ingredientDB = new IngredientDB(connection);
     }
 
 

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeIngredientSearch.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeIngredientSearch.java
@@ -47,7 +47,7 @@ public class RecipeIngredientSearch extends ActivityBase
         super.onCreate(savedInstanceState);
         setContentView(R.layout.fragment_ingredient_storage);
 
-        RecipeIngredientSearchAdapter adapter = new RecipeIngredientSearchAdapter(new IngredientDB());
+        RecipeIngredientSearchAdapter adapter = new RecipeIngredientSearchAdapter(new IngredientDB(getApplicationContext()));
         adapter.setListener(this);
         ingredientRecycleView = findViewById(R.id.ingredient_storage_list);
         ingredientRecycleView.setAdapter(adapter);

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeIngredientSearch.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeIngredientSearch.java
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.wellfed.ActivityBase;
 import com.example.wellfed.R;
+import com.example.wellfed.common.DBConnection;
 import com.example.wellfed.ingredient.Ingredient;
 import com.example.wellfed.ingredient.IngredientDB;
 import com.example.wellfed.ingredient.StorageIngredient;
@@ -47,7 +48,9 @@ public class RecipeIngredientSearch extends ActivityBase
         super.onCreate(savedInstanceState);
         setContentView(R.layout.fragment_ingredient_storage);
 
-        RecipeIngredientSearchAdapter adapter = new RecipeIngredientSearchAdapter(new IngredientDB(getApplicationContext(), false));
+        DBConnection connection = new DBConnection(getApplicationContext());
+        IngredientDB db = new IngredientDB(connection);
+        RecipeIngredientSearchAdapter adapter = new RecipeIngredientSearchAdapter(db);
         adapter.setListener(this);
         ingredientRecycleView = findViewById(R.id.ingredient_storage_list);
         ingredientRecycleView.setAdapter(adapter);

--- a/app/src/main/java/com/example/wellfed/recipe/RecipeIngredientSearch.java
+++ b/app/src/main/java/com/example/wellfed/recipe/RecipeIngredientSearch.java
@@ -47,7 +47,7 @@ public class RecipeIngredientSearch extends ActivityBase
         super.onCreate(savedInstanceState);
         setContentView(R.layout.fragment_ingredient_storage);
 
-        RecipeIngredientSearchAdapter adapter = new RecipeIngredientSearchAdapter(new IngredientDB(getApplicationContext()));
+        RecipeIngredientSearchAdapter adapter = new RecipeIngredientSearchAdapter(new IngredientDB(getApplicationContext(), false));
         adapter.setListener(this);
         ingredientRecycleView = findViewById(R.id.ingredient_storage_list);
         ingredientRecycleView.setAdapter(adapter);


### PR DESCRIPTION
Changes made:

1. Recipe and Ingredient DB updates now link to a user. This is done by setting up the connection with a DBConnection class, which creates a unique user ID for a user if they do not have one, and saves the unique user ID locally. Upon deletion, the unique user ID is removed. This also serves the purpose of completing the recommendations from issue #89 .
2. However, these changes require the application context to be passed to the DB classes whenever instantiated, and a boolean indicating whether it is in testing mode or not. This is a bit clunky, and I would appreciate any suggestions to resolve this.